### PR TITLE
Data Saver Extension for Chrome

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -1286,5 +1286,13 @@
     "link":"https://developers.google.com/realtime/overview",
     "name": "Google Realtime API",
     "type": "service"
+  },
+  {
+    "dateClose": "2019-04-23",
+    "dateOpen": "2015-03-23",
+    "description": "Data Saver extension for Chrome browser allowed it to send webpages through Google servers which compressed them saving bandwidth charges.",
+    "link": "https://blog.chromium.org/2019/04/data-saver-is-now-lite-mode.html",
+    "name": "Data Saver Extension for Chrome",
+    "type": "service"
   }
 ]


### PR DESCRIPTION
It is being retired with Chrome Desktop v74.
https://blog.chromium.org/2019/04/data-saver-is-now-lite-mode.html

